### PR TITLE
Remove Travis JWT plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ script:
 - npm run lint
 - npm run test:unit
 - npm run test:bundle
-- npm run test:sauce
+- 'if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then npm run test:sauce; fi'
 after_success: npm run report-coverage
 addons:
   chrome: stable
-  jwt:
-    secure: fV6M8/p/Cy8dGyKMGjAoiGx/yxUc866yFfjTyJ6EpbPeerdZnpPkCVbMS+OcKHa3Y/RmD6Y+B/VM3sv6afRReu7by/asBsQCA1EJ480ItZ2eLLVObwEtNRTO8qj9YJMDya2Q3KnZJu8lQL+gZXwPariGVfNrleH9hK+uNpq5ToSl+nO9yiUUn0XS4CEJDJni28c0siLnQqkl2iNjReEFhtbEDYGrta0ni1BFIdjPPSJ+L9zWPJBS7hSc8nbVJblcSAF89hBCNL8wttrVzH7CewCV01UdPIKNKMhVYv56Mx/cOUGKAQ8UEt1xBRNhANJb+mwSSginIiYfo1NP5zm/aZIXCy1Okyvqm8XzMI9Qkw1MxRdex+QNLhVARYuVzUtJmvMDLmwD860KubwmOWDXwzVTIBatNTY0FSZyJZ6RSXspRDdOngDfkZlnH8J+/KfbSidBjOIRRzFWyGDQgLFagjcFnBINbaQb0+CPaeM8d1W4pJcYbop0SDr+4QXTaeg3ed1JR+XWxXKRFRomEMt5ANDBSH123607wTpphJKh/VXwJMBnD52XH/KMeimsunAKkjYlGdEI0mVQzZ/LQO+MdBHu4Hm+wW4vBbMWx50mVJAKJQJcbIE19vZ5+iVrXGccY+P+a5i4brAd3bafnSYHBHCcwPn9m/zeR9qTFdnl7Ss=
 cache:
   yarn: true
   directories:
@@ -18,3 +16,5 @@ cache:
 env:
   global:
   - SAUCE_USERNAME: Desire2Learn
+  # SAUCE_ACCESS_KEY
+  - secure: cpu4DdXddutV8VXGwkCiR99jiUwsGiUMshbMhceNJJ7LAjrZCSe9y8uMVIAIwGOjm3Qh8I4arjQjPSdQB9AqsnfpNso1mqMOfoGe4bc9TktnlC24RTE19qemtU42yqt9ktxnPojH0+4/V7u0b4fmbbKzXVMpXt7pt+oB1t7fY7r5cSci7gjTeiajccRRceOs2GD9p/MHiGaW/IP7yqj0QqLFyhGFaP+3mY2VFIL2rBGo/kOvSuRwkM5ACJVSxy1zGTombWRjVBGTqWM6vPiJbCHoBR7hSGwm09V4olic7tzJam5ozKy/UfhDGMihkZsRPsdF/TjZHjxdRr3Uwd/GU6L9BDYbG5fw7YMoMQyKxjEJT1FnO5vTBrQmvZvR4WTG8TJ3gyJTmxvuu2S3zsBQVhdMHfXcmnglrc2hOFWAay/yF/ReKVa5+KiD58pRmfbvI/Szd6UIDKECX/8JlbNxFH+zTyvTuJ3oLcXQZUXNGMTLZPofFvOPLZG5gu1Jt2Op9RG3oZ4RlTZXXuBbAdtlihFJdHo6EMHxbDThiKMb7ZJZSH0bBsW2KgorPM/ES4pNOFv/5U5ZhyEza+rDUWXq68s6rnqVsQfeAb4/dil7ZNpXF/JjM45TkgaBdAuSUKtvJNdmY9OiZviKrXhSHKYEsgXDPeosIeShtH0gkHNDtzk=


### PR DESCRIPTION
As per https://blog.travis-ci.com/2018-01-23-jwt-addon-is-deprecated, the JWT plugin is being deprecated. Instead, use an encrypted SAUCE_ACCESS_KEY.