### PR TITLE
US127307 Added null endpoint check for logUserEvent

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4,6 +4,10 @@ export class Client {
 	}
 
 	logUserEvent(event) {
+		if (!this.options.endpoint) {
+			return;
+		}
+
 		var requestObject = {
 			method: 'POST'
 		};

--- a/test/index.js
+++ b/test/index.js
@@ -68,4 +68,36 @@ describe('test suite', () => {
 			});
 		});
 	});
+
+	describe('logUserEvent - with null endpoint', () => {
+		var fetch, client, event;
+
+		before(() => {
+			client = new Client({
+				endpoint: null
+			});
+
+			event = new TelemetryEvent();
+			const eventBody = new EventBody();
+			event.setBody(eventBody);
+
+			fetch = sinon.stub(window.d2lfetch, 'fetch');
+			var promise = Promise.resolve({
+				ok: true,
+				json: function() {
+					return Promise.resolve();
+				}
+			});
+			fetch.returns(promise);
+		});
+
+		after(() => {
+			fetch && fetch.restore();
+		});
+
+		it ('POSTs an event', () => {
+			client.logUserEvent(event);
+			expect(fetch.calledWith(sinon.match.has('method', 'POST'))).to.be.false;
+		});
+	});
 });


### PR DESCRIPTION
### Motivation/Context
* As part of the PBMM work we need to ensure we do not log telemetry events for Protected B clients so the case where data telemetry endpoint could be `null` is more likely to happen now. Through testing, it's found that the new lessons experience logs the telemetry event JSON objects in the console and errors out. This PR is aimed to fix that issue.

Related PR: https://github.com/Brightspace/lms/pull/10201

### Summary of Changes
* When data telemetry endpoint is null, no network request is created to log the telemetry event
* Added test for null data telemetry endpoint

### Rally Story
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F600523947568&fdp=true?fdp=true