### PR TITLE
US127286 - Add no-cors to POST init options

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -9,7 +9,8 @@ export class Client {
 		}
 
 		var requestObject = {
-			method: 'POST'
+			method: 'POST',
+			mode: 'no-cors'
 		};
 
 		if (event) {


### PR DESCRIPTION
[Rally](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F600432550308)

Been getting a 502 when trying to bubble telemetry events upstream from mastery view details. Fix is a bit of a shot in the dark since the issue doesn't repro locally. Also assumes that we're getting this same error in both QA and prod

![image](https://user-images.githubusercontent.com/11915922/143898454-c3fefdda-e4fc-4ca8-9631-b6db1d9e4eac.png)
