### PR TITLE
US133384: Force all Context.Id values to `string` if 'id' exists

### DIFF
--- a/src/eventBody.js
+++ b/src/eventBody.js
@@ -27,7 +27,7 @@ export class EventBody {
 		this._context = {};
 
 		if (id) {
-			this._context.Id = id;
+			this._context.Id = id.toString();
 		}
 		if (type) {
 			this._context.Type = type;

--- a/src/eventBody.js
+++ b/src/eventBody.js
@@ -45,7 +45,7 @@ export class EventBody {
 		this._object = {};
 
 		if (id) {
-			this._object.Id = id.toString();;
+			this._object.Id = id.toString();
 		}
 		if (type) {
 			this._object.Type = type;
@@ -63,7 +63,7 @@ export class EventBody {
 		this._target = {};
 
 		if (id) {
-			this._target.Id = id.toString();;
+			this._target.Id = id.toString();
 		}
 		if (type) {
 			this._target.Type = type;

--- a/src/eventBody.js
+++ b/src/eventBody.js
@@ -45,7 +45,7 @@ export class EventBody {
 		this._object = {};
 
 		if (id) {
-			this._object.Id = id;
+			this._object.Id = id.toString();;
 		}
 		if (type) {
 			this._object.Type = type;
@@ -63,7 +63,7 @@ export class EventBody {
 		this._target = {};
 
 		if (id) {
-			this._target.Id = id;
+			this._target.Id = id.toString();;
 		}
 		if (type) {
 			this._target.Type = type;


### PR DESCRIPTION
[US133384](https://rally1.rallydev.com/#/?detail=/userstory/613522777211&fdp=true): Telemetry Service > Enforce schema validation